### PR TITLE
Escape python2 command in Darwin (In Darwin, python2 command is not supported).

### DIFF
--- a/shell_support.in
+++ b/shell_support.in
@@ -8,9 +8,15 @@
 # Licensed under the Eclipse Public License -v 1.0 (EPL)
 # http://www.opensource.org/licenses/eclipse-1.0.txt
 
+if [ `uname` = "Darwin" ]; then
+   PYTHON_COMMAND=python
+elif [ `uname` = "Linux" ]; then
+   PYTHON_COMMAND=python2
+fi
+
 rtcwd()
 {
-   eval $(python2 -c "import sys; import rtshell.rtcwd; sys.exit(rtshell.rtcwd.main(['${1}']))")
+   eval $($PYTHON_COMMAND -c "import sys; import rtshell.rtcwd; sys.exit(rtshell.rtcwd.main(['${1}']))")
 }
 
 rtvis()


### PR DESCRIPTION
This might work well in Darwin and Linux. I tested in OSX10.9.3, and Ubuntu 13.04.
