### PR TITLE
Fix rts to dot

### DIFF
--- a/rtshell/rtstodot.py
+++ b/rtshell/rtstodot.py
@@ -43,16 +43,11 @@ def escape(s):
 def get_ports(rtsp):
     in_ports = []
     out_ports = []
-    for dp in rtsp.data_port_connectors:
-        in_ports.append((dp.source_data_port.instance_name,
-            port_name(dp.source_data_port.port_name)))
-        out_ports.append((dp.target_data_port.instance_name,
-            port_name(dp.target_data_port.port_name)))
-    for sp in rtsp.service_port_connectors:
-        out_ports.append((dp.source_data_port.instance_name,
-            port_name(dp.source_data_port.port_name)))
-        in_ports.append((dp.target_data_port.instance_name,
-            port_name(dp.target_data_port.port_name)))
+    for p in rtsp.service_port_connectors+rtsp.data_port_connectors:
+        out_ports.append((p.source_data_port.instance_name,
+            port_name(p.source_data_port.port_name)))
+        in_ports.append((p.target_data_port.instance_name,
+            port_name(p.target_data_port.port_name)))
     return in_ports, out_ports
 
 

--- a/rtshell/rtstodot.py
+++ b/rtshell/rtstodot.py
@@ -37,7 +37,7 @@ def port_name(s):
 
 
 def escape(s):
-    return s.replace('.', '_dot_').replace('/', '_slash_')
+    return s.replace('.', '_dot_').replace('/', '_slash_').replace('(', '_lpar_').replace(')', '_rpar_')
 
 
 def get_ports(rtsp):


### PR DESCRIPTION
This PR implements the changes discussed in #38 and #37:

- Escape parentheses in component names
- Connect data ports and service ports in the right order (while slightly simplifying the logic there)

Without the parentheses change:
> Warning: test.dot: syntax error in line 4 near '('

Without the port order change:
![test_nochange](https://cloud.githubusercontent.com/assets/4352562/22814584/2e863d5c-ef98-11e6-9642-757dd0d660c1.png)

Final version:
![test](https://cloud.githubusercontent.com/assets/4352562/22814585/2e86832a-ef98-11e6-884f-dc57c89569eb.png)

Cheers!